### PR TITLE
핵심 UI 쉘(Shell) 및 라우팅 설정

### DIFF
--- a/lib/common/widgets/main_shell.dart
+++ b/lib/common/widgets/main_shell.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+// 1. 탭의 '동작'을 나타내는 함수(onTap)를 포함하도록 데이터 클래스를 확장합니다.
+class _NavigationTab {
+  final String routePath; // 현재 경로와 비교하기 위한 경로
+  final IconData icon;
+  final IconData activeIcon;
+  final String label;
+  final void Function(BuildContext context, WidgetRef ref)
+  onTap; // 탭을 눌렀을 때 실행될 '동작'
+
+  const _NavigationTab({
+    required this.routePath,
+    required this.icon,
+    required this.activeIcon,
+    required this.label,
+    required this.onTap,
+  });
+}
+
+// 2. MainShell을 StatelessWidget에서 ConsumerWidget으로 변경합니다.
+//    이는 onTap 함수 내부에서 ref를 사용하여 Provider를 읽을 수 있도록 하기 위함입니다.
+class MainShell extends ConsumerWidget {
+  final Widget child;
+
+  const MainShell({super.key, required this.child});
+
+  // 3. 탭 목록을 정의할 때, 각 탭이 눌렸을 때 수행할 '동작'까지 함께 정의합니다.
+  static final _tabs = [
+    _NavigationTab(
+      routePath: '/map',
+      icon: Icons.map_outlined,
+      activeIcon: Icons.map,
+      label: '지도',
+      onTap: (context, ref) => context.go('/map'), // 단순 페이지 이동
+    ),
+    _NavigationTab(
+      routePath: '/profile',
+      icon: Icons.person_outline,
+      activeIcon: Icons.person,
+      label: '내 정보',
+      // '내 정보' 탭은 더 복잡한 동작을 가집니다.
+      onTap: (context, ref) {
+        // --- ▼▼▼ 로그인 기능 추가 시 이 부분만 수정하면 됩니다 ▼▼▼ ---
+
+        // final currentUser = ref.read(authProvider); // 예시: 나중에 authProvider를 읽어옴
+        final currentUser = null; // 현재는 로그인 기능이 없으므로 null로 가정
+
+        if (currentUser != null) {
+          // context.go('/profile/${currentUser.id}');
+        } else {
+          // 로그인하지 않았을 때의 동작 (예: 로그인 안내 스낵바 표시)
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('로그인이 필요한 기능입니다. (나중에 구현될 예정)'),
+              duration: Duration(seconds: 1),
+            ),
+          );
+        }
+        // --- ▲▲▲ 여기까지 ---
+      },
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // build 메소드에 ref 추가
+    return Scaffold(
+      body: child,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _tabs.indexWhere(
+          (tab) => GoRouterState.of(
+            context,
+          ).uri.toString().startsWith(tab.routePath),
+        ),
+
+        // 4. onTap 콜백은 이제 탭에 정의된 동작을 실행하기만 합니다.
+        //    MainShell은 각 탭이 무슨 일을 하는지 더 이상 알 필요가 없습니다.
+        onTap: (index) => _tabs[index].onTap(context, ref),
+
+        items: _tabs
+            .map(
+              (tab) => BottomNavigationBarItem(
+                icon: Icon(tab.icon),
+                activeIcon: Icon(tab.activeIcon),
+                label: tab.label,
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}

--- a/lib/core/navigation/router.dart
+++ b/lib/core/navigation/router.dart
@@ -1,0 +1,30 @@
+import 'package:go_router/go_router.dart';
+import 'package:mongle_flutter/common/widgets/main_shell.dart';
+import 'package:mongle_flutter/features/feed/presentation/screens/feed_screen.dart';
+import 'package:mongle_flutter/features/map/presentation/screens/map_screen.dart';
+import 'package:mongle_flutter/features/profile/presentation/screens/profile_screen.dart';
+
+// GoRouter 설정을 앱 전역에서 사용할 수 있도록 인스턴스를 생성합니다.
+final GoRouter router = GoRouter(
+  // 앱이 처음 시작될 때 보여줄 경로를 지정합니다.
+  initialLocation: '/map',
+
+  // 경로 목록을 정의합니다.
+  routes: [
+    // MainShell은 하단 탭을 가지고 있으며, 그 안의 내용은 자식(child) 경로에 따라 바뀝니다.
+    ShellRoute(
+      builder: (context, state, child) {
+        return MainShell(child: child);
+      },
+      // ShellRoute 안에 포함될 자식 경로들을 정의합니다.
+      routes: [
+        GoRoute(path: '/map', builder: (context, state) => const MapScreen()),
+        GoRoute(path: '/feed', builder: (context, state) => const FeedScreen()),
+        GoRoute(
+          path: '/profile',
+          builder: (context, state) => const ProfileScreen(),
+        ),
+      ],
+    ),
+  ],
+);

--- a/lib/features/feed/presentation/screens/feed_screen.dart
+++ b/lib/features/feed/presentation/screens/feed_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class FeedScreen extends StatelessWidget {
+  const FeedScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('피드 화면')));
+  }
+}

--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class MapScreen extends StatelessWidget {
+  const MapScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('지도 화면')));
+  }
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('프로필 화면')));
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongle_flutter/core/navigation/router.dart'; // 방금 만든 라우터 import
 
 void main() {
   // TODO: 추후 Firebase, Naver Map 등 비동기 초기화 로직 추가 예정
 
   runApp(
-    // Riverpod를 앱 전체에서 사용하기 위해 ProviderScope로 감싸줍니다..
+    // Riverpod를 앱 전체에서 사용하기 위해 ProviderScope로 감싸줍니다.
     const ProviderScope(child: MyApp()),
   );
 }
@@ -15,11 +16,12 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      // TODO: 추후 GoRouter 설정 연동 예정
-      home: Scaffold(
-        appBar: AppBar(title: const Text('몽글 (MONGLE)')),
-        body: const Center(child: Text('프로젝트 기반 설정 완료!')),
+    return MaterialApp.router(
+      routerConfig: router,
+      title: '몽글 (MONGLE)',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
       ),
     );
   }


### PR DESCRIPTION
## 📄Summary
-   [ ] **1. `MainShell` 위젯 생성**
    -   `lib/common/widgets/main_shell.dart` 파일을 생성합니다.
    -   `Scaffold`와 `BottomNavigationBar`를 사용하여 2개의 탭('지도', '내 정보')을 가진 기본 UI 뼈대를 만듭니다.
    -  추후 '피드' 탭을 네비게이션 바에 추가할 것이므로 확장가능하게 코드를 짜야합니다.

-   [ ] **2. `GoRouter` 설정**
    -   `lib/core/navigation/router.dart` 파일을 생성합니다.
    -   `GoRouter`를 설정하고, `MainShell`을 사용하는 `ShellRoute`를 정의합니다.
    -   각 탭의 초기 경로(e.g., `/map`, `/feed`, `/profile`)와 연결될 임시 화면(e.g., `Placeholder` 위젯)을 생성합니다.

-   [ ] **3. `main.dart`에 라우터 적용**
    -   `main.dart`의 `MyApp` 위젯을 `MaterialApp.router`를 사용하도록 변경합니다.
    -   `routerConfig`에 위에서 생성한 `GoRouter` 인스턴스를 연결합니다.

<br><br>

## 🙋🏻 More
- 논의하고 싶은 내용 등

<br><br>

## 🔗관련 이슈
- Close #7 
