### PR TITLE
feat(map): 지도 화면 기본 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+
+# env
+.env

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <application
         android:label="Mongle"
         android:name="${applicationName}"

--- a/lib/features/map/presentation/screens/map_screen.dart
+++ b/lib/features/map/presentation/screens/map_screen.dart
@@ -1,10 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mongle_flutter/features/map/presentation/viewmodels/map_viewmodel.dart';
+import 'package:mongle_flutter/features/map/presentation/widgets/map_view.dart';
 
-class MapScreen extends StatelessWidget {
+class MapScreen extends ConsumerWidget {
   const MapScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('지도 화면')));
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 2. ref.watch를 사용하여 mapViewModelProvider의 상태 변화를 감지합니다.
+    //    상태가 바뀔 때마다 이 build 메소드는 자동으로 다시 실행됩니다.
+    final mapState = ref.watch(mapViewModelProvider);
+
+    // 3. freezad 덕분에 when 메소드를 사용하여 모든 상태를 안전하게 처리할 수 있습니다.
+    return mapState.when(
+      // 로딩 중일 때 보여줄 UI
+      loading: () => const Center(child: CircularProgressIndicator()),
+      // 에러 발생 시 보여줄 UI
+      error: (message) => Center(child: Text(message)),
+      // 데이터 로딩 성공 시 보여줄 UI
+      data: (initialPosition) => MapView(initialPosition: initialPosition),
+    );
   }
 }

--- a/lib/features/map/presentation/viewmodels/map_viewmodel.dart
+++ b/lib/features/map/presentation/viewmodels/map_viewmodel.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_naver_map/flutter_naver_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+part 'map_viewmodel.freezed.dart';
+
+// 1. 지도 화면이 가질 수 있는 상태들을 정의합니다.
+@freezed
+class MapState with _$MapState {
+  const factory MapState.loading() = _Loading;
+  const factory MapState.error(String message) = _Error;
+  const factory MapState.data({required NLatLng initialPosition}) = _Data;
+}
+
+// 2. 상태를 관리하고 비즈니스 로직을 수행할 ViewModel(Notifier)을 구현합니다.
+class MapViewModel extends StateNotifier<MapState> {
+  MapViewModel() : super(const MapState.loading()) {
+    _init(); // ViewModel이 생성되자마자 초기화 로직을 실행합니다.
+  }
+
+  Future<void> _init() async {
+    // 2. permission_handler로 권한 요청 및 상태 확인
+    final status = await Permission.location.request();
+
+    if (status.isGranted) {
+      // 3. 권한이 허용되었다면, 위치 정보 가져오기 시도
+      try {
+        final position = await Geolocator.getCurrentPosition();
+        state = MapState.data(
+          initialPosition: NLatLng(position.latitude, position.longitude),
+        );
+      } catch (e) {
+        state = MapState.error('위치를 가져오는 데 실패했습니다: ${e.toString()}');
+      }
+    } else if (status.isDenied) {
+      // 4. 권한이 거부된 경우
+      state = const MapState.error('위치 권한이 거부되었습니다.');
+    } else if (status.isPermanentlyDenied) {
+      // 5. 권한이 영구적으로 거부된 경우 (사용자가 직접 설정으로 가야 함)
+      state = const MapState.error('위치 권한이 영구적으로 거부되었습니다. 앱 설정에서 허용해주세요.');
+      // openAppSettings(); // 이 함수를 호출해 바로 앱 설정 화면으로 보낼 수 있습니다.
+    }
+  }
+}
+
+// 3. ViewModel을 앱 전역에서 사용할 수 있도록 Provider를 생성합니다.
+final mapViewModelProvider =
+    StateNotifierProvider.autoDispose<MapViewModel, MapState>(
+      (ref) => MapViewModel(),
+    );

--- a/lib/features/map/presentation/viewmodels/map_viewmodel.freezed.dart
+++ b/lib/features/map/presentation/viewmodels/map_viewmodel.freezed.dart
@@ -1,0 +1,350 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'map_viewmodel.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$MapState {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MapState);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'MapState()';
+}
+
+
+}
+
+/// @nodoc
+class $MapStateCopyWith<$Res>  {
+$MapStateCopyWith(MapState _, $Res Function(MapState) __);
+}
+
+
+/// Adds pattern-matching-related methods to [MapState].
+extension MapStatePatterns on MapState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( _Loading value)?  loading,TResult Function( _Error value)?  error,TResult Function( _Data value)?  data,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Loading() when loading != null:
+return loading(_that);case _Error() when error != null:
+return error(_that);case _Data() when data != null:
+return data(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( _Loading value)  loading,required TResult Function( _Error value)  error,required TResult Function( _Data value)  data,}){
+final _that = this;
+switch (_that) {
+case _Loading():
+return loading(_that);case _Error():
+return error(_that);case _Data():
+return data(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( _Loading value)?  loading,TResult? Function( _Error value)?  error,TResult? Function( _Data value)?  data,}){
+final _that = this;
+switch (_that) {
+case _Loading() when loading != null:
+return loading(_that);case _Error() when error != null:
+return error(_that);case _Data() when data != null:
+return data(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  loading,TResult Function( String message)?  error,TResult Function( NLatLng initialPosition)?  data,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Loading() when loading != null:
+return loading();case _Error() when error != null:
+return error(_that.message);case _Data() when data != null:
+return data(_that.initialPosition);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  loading,required TResult Function( String message)  error,required TResult Function( NLatLng initialPosition)  data,}) {final _that = this;
+switch (_that) {
+case _Loading():
+return loading();case _Error():
+return error(_that.message);case _Data():
+return data(_that.initialPosition);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  loading,TResult? Function( String message)?  error,TResult? Function( NLatLng initialPosition)?  data,}) {final _that = this;
+switch (_that) {
+case _Loading() when loading != null:
+return loading();case _Error() when error != null:
+return error(_that.message);case _Data() when data != null:
+return data(_that.initialPosition);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _Loading implements MapState {
+  const _Loading();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Loading);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'MapState.loading()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class _Error implements MapState {
+  const _Error(this.message);
+  
+
+ final  String message;
+
+/// Create a copy of MapState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ErrorCopyWith<_Error> get copyWith => __$ErrorCopyWithImpl<_Error>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Error&&(identical(other.message, message) || other.message == message));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'MapState.error(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ErrorCopyWith<$Res> implements $MapStateCopyWith<$Res> {
+  factory _$ErrorCopyWith(_Error value, $Res Function(_Error) _then) = __$ErrorCopyWithImpl;
+@useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class __$ErrorCopyWithImpl<$Res>
+    implements _$ErrorCopyWith<$Res> {
+  __$ErrorCopyWithImpl(this._self, this._then);
+
+  final _Error _self;
+  final $Res Function(_Error) _then;
+
+/// Create a copy of MapState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? message = null,}) {
+  return _then(_Error(
+null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class _Data implements MapState {
+  const _Data({required this.initialPosition});
+  
+
+ final  NLatLng initialPosition;
+
+/// Create a copy of MapState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$DataCopyWith<_Data> get copyWith => __$DataCopyWithImpl<_Data>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Data&&(identical(other.initialPosition, initialPosition) || other.initialPosition == initialPosition));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,initialPosition);
+
+@override
+String toString() {
+  return 'MapState.data(initialPosition: $initialPosition)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$DataCopyWith<$Res> implements $MapStateCopyWith<$Res> {
+  factory _$DataCopyWith(_Data value, $Res Function(_Data) _then) = __$DataCopyWithImpl;
+@useResult
+$Res call({
+ NLatLng initialPosition
+});
+
+
+
+
+}
+/// @nodoc
+class __$DataCopyWithImpl<$Res>
+    implements _$DataCopyWith<$Res> {
+  __$DataCopyWithImpl(this._self, this._then);
+
+  final _Data _self;
+  final $Res Function(_Data) _then;
+
+/// Create a copy of MapState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? initialPosition = null,}) {
+  return _then(_Data(
+initialPosition: null == initialPosition ? _self.initialPosition : initialPosition // ignore: cast_nullable_to_non_nullable
+as NLatLng,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/map/presentation/widgets/map_view.dart
+++ b/lib/features/map/presentation/widgets/map_view.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_naver_map/flutter_naver_map.dart';
+
+class MapView extends StatelessWidget {
+  // 1. MapScreen으로부터 지도의 초기 위치를 전달받음
+  final NLatLng initialPosition;
+
+  const MapView({super.key, required this.initialPosition});
+
+  @override
+  Widget build(BuildContext context) {
+    // 2. NaverMap 위젯과 모든 설정 옵션이 이곳으로 이동
+    return NaverMap(
+      options: NaverMapViewOptions(
+        initialCameraPosition: NCameraPosition(
+          target: initialPosition,
+          zoom: 15,
+        ),
+        locationButtonEnable: true,
+      ),
+      // 여기에 마커 추가 등 지도 관련 로직을 계속해서 추가할 수 있습니다.
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,34 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_naver_map/flutter_naver_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mongle_flutter/core/navigation/router.dart'; // 방금 만든 라우터 import
+import 'package:mongle_flutter/core/navigation/router.dart';
 
-void main() {
+void main() async {
   // TODO: 추후 Firebase, Naver Map 등 비동기 초기화 로직 추가 예정
+  // 1. runApp() 전에 Flutter 엔진과 위젯 바인딩이 준비되도록 보장합니다.
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // 2. .env 파일을 로드합니다.
+  await dotenv.load(fileName: ".env");
+  final naverMapClientId = dotenv.env['NAVER_MAP_CLIENT_ID'];
+
+  // 3. Naver Map SDK를 초기화합니다. Client ID는 .env 파일에서 안전하게 가져옵니다.
+  await FlutterNaverMap().init(
+    clientId: naverMapClientId!,
+    onAuthFailed: (ex) {
+      switch (ex) {
+        case NQuotaExceededException(:final message):
+          print("사용량 초과 (message: $message)");
+          break;
+        case NUnauthorizedClientException() ||
+            NClientUnspecifiedException() ||
+            NAnotherAuthFailedException():
+          print("인증 실패: $ex");
+          break;
+      }
+    },
+  );
 
   runApp(
     // Riverpod를 앱 전체에서 사용하기 위해 ProviderScope로 감싸줍니다.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -278,6 +278,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: d4130c4a43e0b13fefc593bc3961f2cb46e30cb79e253d4a526b1b5d24ae1ce4
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -640,6 +648,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.1"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.7"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   geolocator:
   firebase_core:
   firebase_auth:
+  flutter_dotenv: ^6.0.0
+  permission_handler: ^12.0.1
 
 dev_dependencies:
   flutter_test:
@@ -70,10 +72,8 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
+  assets:
+    - .env
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
## 📄Summary
- 이슈 #9  의 요구사항에 따라 지도 화면의 기본 기능을 구현했습니다.
- Riverpod의 `StateNotifier`와 `freezed`를 사용하여 지도 상태(`loading`, `data`, `error`)를 관리하는 `MapViewModel`을 구현했습니다.
- Race Condition을 방지하기 위해 ViewModel 생성 시 사용자의 현재 위치를 비동기적으로 **단 한 번만** 호출하여 상태로 관리합니다.
- `MapScreen`에서는 ViewModel의 상태 변화를 감지하여 상태에 따라 로딩 인디케이터, 에러 메시지, 지도 UI를 적절히 표시합니다.
- 단일 책임 원칙과 재사용성을 높이기 위해 실제 `NaverMap` 위젯을 별도의 `MapView` 위젯으로 분리하는 리팩토링을 진행했습니다.

<br><br>

## 🙋🏻 More
- 현재는 안정적으로 지도를 띄우고 사용자의 초기 위치를 표시하는 것까지 구현되었습니다.

<br><br>

## 🔗관련 이슈
- Close #9 